### PR TITLE
new method Peer.isConnected()

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -64,6 +64,7 @@ function Peer(id, options) {
     this.id = id;
     this._init();
   } else {
+    this.id = null;
     this._getId();
   }
 };
@@ -276,6 +277,14 @@ Peer.prototype.connect = function(peer, options) {
 };
 
 /**
+ * Return the peer id or null, if there's no id at the moment.
+ * Reasons for no id could be 'connect in progress' or 'disconnected'
+ */
+Peer.prototype.getId = function() {
+  return this.id;
+};
+
+/**
  * Destroys the Peer: closes all active connections as well as the connection
  *  to the server.
  * Warning: The peer can no longer create or accept connections after being
@@ -297,6 +306,7 @@ Peer.prototype.destroy = function() {
 Peer.prototype.disconnect = function() {
   if (!this.disconnected) {
     this._socket.close();
+    this.id = null;
     this.disconnected = true;
   }
 };


### PR DESCRIPTION
This method should be used for detecting if there's an active connection to the peer server instead of usage of Peer.disconnected, because this field is used internally and with this function the behavior internally can change later without problems.
