### PR TITLE
Have examples run from the peer.js in the dist folder

### DIFF
--- a/examples/chat-old.html
+++ b/examples/chat-old.html
@@ -1,20 +1,20 @@
-<!DOCTYPE HTML> 
-<html lang="en"> 
+<!DOCTYPE HTML>
+<html lang="en">
 <head>
 <title>PeerJS chat demo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
-<meta http-equiv="Content-Language" content="en-us"> 
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Language" content="en-us">
 
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script> 
-<script type="text/javascript" src="http://cdn.peerjs.com/0/peer.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+<script type="text/javascript" src="../dist/peer.js"></script>
 <script>
-  
+
   var conn;
   // Connect to PeerJS, have server assign an ID instead of providing one
   var peer = new Peer({key: 'lwjd5qra8257b9', debug: true});
   peer.on('open', function(id){
     $('#pid').text(id);
-  });  
+  });
   // Await connections from others
   peer.on('connection', connect);
   function connect(c) {
@@ -33,7 +33,7 @@
       c.on('open', function(){
         connect(c);
       });
-      c.on('error', function(err){ alert(err) });  
+      c.on('error', function(err){ alert(err) });
     });
     // Send a chat message
     $('#send').click(function(){
@@ -47,27 +47,27 @@
   });
 
 </script>
-</head> 
- 
-<body> 
+</head>
+
+<body>
 
   Your PeerJS id is : <span id="pid"></span><br><br>
   Connect to peer: <input type="text" id="rid" placeholder="Someone else's id">
                    <input type="button" value="Connect" id="connect"><br><br>
-  
-  
+
+
   <div id="chat_area" style="display: none;">
     <div id="messages"></div>
     <input type="text" id="text" placeholder="Enter message">
     <input type="button" value="Send" id="send">
   </div>
-  
 
-  
-  
+
+
+
   <br><br><br>
   <p style="font-size: 10px;">Your browser version: <span id="browsers"></span><br>
   Currently <strong>Google Chrome 26.0.1403.0 or above</strong> is required (Dev or Canary channels)</strong><br><br>For more up to date compatibility information see <a href="http://peerjs.com/status">PeerJS WebRTC Status</a><br><br>Note that this demo may also fail if you are behind stringent firewalls or both you and the remote peer and behind symmetric NATs.</p>
-  
-</body> 
-</html> 
+
+</body>
+</html>

--- a/examples/chat.html
+++ b/examples/chat.html
@@ -1,14 +1,14 @@
-<!DOCTYPE HTML> 
-<html lang="en"> 
+<!DOCTYPE HTML>
+<html lang="en">
 <head>
 <title>PeerJS chat demo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
-<meta http-equiv="Content-Language" content="en-us"> 
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Language" content="en-us">
 
 <link href="fancy.css" rel="stylesheet" type="text/css">
 
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js"></script> 
-<script type="text/javascript" src="http://cdn.peerjs.com/0/peer.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js"></script>
+<script type="text/javascript" src="../dist/peer.js"></script>
 <script>
 // Connect to PeerJS, have server assign an ID instead of providing one
 var peer = new Peer({key: 'lwjd5qra8257b9', debug: true});
@@ -30,7 +30,7 @@ function connect(c) {
     var messages = $('<div><em>Peer connected.</em></div>').addClass('messages');
     chatbox.append(header);
     chatbox.append(messages);
- 
+
     // Select connection handler.
     chatbox.on('click', function() {
       if ($(this).attr('class').indexOf('active') === -1) {
@@ -152,9 +152,9 @@ window.onunload = window.onbeforeunload = function(e) {
 };
 
 </script>
-</head> 
- 
-<body> 
+</head>
+
+<body>
   <a href="https://github.com/peers/peerjs"><img style="position: absolute; top: 0; right: 0; border: 0;"
     src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"
     alt="Fork me on GitHub"></a>
@@ -176,13 +176,13 @@ window.onunload = window.onbeforeunload = function(e) {
   <div id="box" style="background: #fff; font-size: 18px;padding:40px 30px; text-align: center;">
     Drag file here to send to active connections.
   </div>
-  
-  
+
+
   <div class="warning browser"><div class="important">Your browser version: <span id="browsers"></span><br>
   Currently <strong>Google Chrome 26.0.1403.0 or above</strong> is required.</strong></div>For more up to date compatibility
 information see <a href="http://peerjs.com/status">PeerJS WebRTC
   Status</a><br>Note that this demo may also fail if you are behind
 stringent firewalls or both you and the remote peer and behind symmetric
 NATs.</div>
-</body> 
-</html> 
+</body>
+</html>

--- a/examples/helloworld.html
+++ b/examples/helloworld.html
@@ -1,12 +1,12 @@
-<!DOCTYPE HTML> 
-<html lang="en"> 
+<!DOCTYPE HTML>
+<html lang="en">
 <head>
 <title>PeerJS Hello World Code Example</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
-<meta http-equiv="Content-Language" content="en-us"> 
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Language" content="en-us">
 
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script> 
-<script type="text/javascript" src="http://cdn.peerjs.com/0/peer.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+<script type="text/javascript" src="../dist/peer.js"></script>
 <script>
   // This is a very simple code example. See chat.html for a more involved
   // example.
@@ -85,9 +85,9 @@
     font-weight: 600;
   }
 </style>
-</head> 
- 
-<body> 
+</head>
+
+<body>
   <a href="https://github.com/peers/peerjs"><img style="position: absolute; top: 0; right: 0; border: 0;"
     src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"
     alt="Fork me on GitHub"></a>
@@ -111,5 +111,5 @@
 information see <a href="http://peerjs.com/status">PeerJS WebRTC
   Status</a><br>Note that this demo may also fail if you are behind
 stringent firewalls.</div></div>
-</body> 
-</html> 
+</body>
+</html>


### PR DESCRIPTION
While developing, it's useful to have the examples run from the copy of peer.js you just built.
