### PR TITLE
Make Chrome and Firefox interoperable for large messages

### DIFF
--- a/lib/dataconnection.js
+++ b/lib/dataconnection.js
@@ -163,7 +163,8 @@ DataConnection.prototype.send = function(data, chunked) {
     var utf8 = (this.serialization === 'binary-utf8');
     var blob = util.pack(data, utf8);
 
-    if (util.browser !== 'Firefox' && !chunked && blob.size > util.chunkedMTU) {
+    // For Chrome-Firefox interoperability, we need to make Firefox "chunking" the data it sends out. Future sophistication of this approach could make the decision on chunking dependent on the remote browser.
+    if (/*util.browser !== 'Firefox' && */!chunked && blob.size > util.chunkedMTU) {
       this._sendChunks(blob);
       return;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,7 +6,7 @@ var util = {
 
   CLOUD_HOST: '0.peerjs.com',
   CLOUD_PORT: 9000,
-  chunkedMTU: 60000, // 60KB
+  chunkedMTU: 16300, // The original 60000 bytes setting does not work when sending data from Firefox to Chrome, which is "cut off" after 16384 bytes and delivered individually. I suspect a bug in either Chrome or Firefox behind this.
 
   // Logging logic
   logLevel: 0,
@@ -107,11 +107,14 @@ var util = {
 
     if (data) {
       // Binary test
+      // Commented out the "binary blob" feature detection. Firefox supports sending Blobs, whereas Chrome does not. Hence we agree on the common denominator (which is using plain ArrayBuffers).
+      /*
       try {
         dc.binaryType = 'blob';
         binaryBlob = true;
       } catch (e) {
       }
+      */
 
       // Reliable test.
       // Unfortunately Chrome is a bit unreliable about whether or not they


### PR DESCRIPTION
In an attempt to make Chrome and Firefox interoperable on reliable data channels, I made the following changes:

(1) All messages above the "chunkedMTU" threshold are being chunked - both in Firefox and in Chrome.
(2) As Blobs are not supported in Chrome's data channels, Firefox also falls back to ArrayBuffers
(3) Surprisingly, I also had to reduce the "chunkedMTU" property to ~16000 bytes (from 60000). This is because of the following phenomenon: Chrome can send data to Firefox in 60000 byte blocks. However the other way around when Firefox sends data to Chrome in 60000 byte blocks, these get split up into 16384 byte blocks. At this point, I cannot say if Firefox (the sender) or Chrome (the receiver) does this. At any rate, the "onmessage" callback of the WebRTC DataConnection object is called with data that is no larger than 16384 bytes. As a result, the "unpacker" gets confused. To work around this, I reduced the chunkedMTU threshold to 16300 bytes. 
