### PR TITLE
Store token to be accessible from outside

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -27,6 +27,7 @@ Socket.prototype.start = function(id) {
   var token = util.randomToken();
   this._httpUrl += '/' + id + '/' + token;
   this._wsUrl += '&id='+id+'&token='+token;
+  this.token = token;
 
   this._startXhrStream();
   this._startWebSocket();


### PR DESCRIPTION
Tokens are not acessible from outside for the moment.
Set peer.token with the peer's token.
