### PR TITLE
Include peers that are connected to you "passively"

### DIFF
--- a/examples/chat.html
+++ b/examples/chat.html
@@ -81,6 +81,7 @@ function connect(c) {
       }
     });
   }
+  connectedPeers[c.peer] = 1;
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
When somebody connects to your session the browser doesn't record the newly connected peer id in connectedPeers. This patch fixes the issue
