### PR TITLE
add prefix options

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -38,6 +38,11 @@
             "description": "<code>true</code> if you're using SSL.<span class='tip'>Note that our cloud-hosted server and assets may not support SSL.</span>"
           },
           {
+            "name": "prefix",
+            "type": "string",
+            "description": "Default prefix for building paths. Useful when using behind a proxy with another server. Default to <code>'/'</code>"
+          },
+          {
             "name": "config",
             "type": "object",
             "description": "Configuration hash passed to RTCPeerConnection. This hash contains any custom ICE/TURN server configuration. Defaults to <code>{ 'iceServers': [{ 'url': 'stun:stun.l.google.com:19302' }] }</code>"

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -21,6 +21,7 @@ function Peer(id, options) {
     host: util.CLOUD_HOST,
     port: util.CLOUD_PORT,
     key: 'peerjs',
+    prefix: '/',
     config: util.defaultConfig
   }, options);
   this.options = options;
@@ -32,6 +33,15 @@ function Peer(id, options) {
   if (options.secure === undefined && options.host !== util.CLOUD_HOST) {
     options.secure = util.isSecure();
   }
+
+  if ((options.prefix !== '/') {
+    if (!(/^\//).test(options.prefix)) 
+      options.prefix = '/' + options.prefix;
+
+    if (!(/\/$/).test(options.prefix))
+      options.prefix = options.prefix + '/';
+  )
+
   // Set a custom log function if present
   if (options.logFunction) {
     util.setLogFunction(options.logFunction);
@@ -107,7 +117,8 @@ Peer.prototype._retrieveId = function(cb) {
   var self = this;
   var http = new XMLHttpRequest();
   var protocol = this.options.secure ? 'https://' : 'http://';
-  var url = protocol + this.options.host + ':' + this.options.port + '/' + this.options.key + '/id';
+  var url = [protocol, this.options.host, ':', this.options.port, 
+    this.options.prefix, this.options.key, '/id'].join("");
   var queryString = '?ts=' + new Date().getTime() + '' + Math.random();
   url += queryString;
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -2,8 +2,8 @@
  * An abstraction on top of WebSockets and XHR streaming to provide fastest
  * possible connection for peers.
  */
-function Socket(secure, host, port, key) {
-  if (!(this instanceof Socket)) return new Socket(secure, host, port, key);
+function Socket(secure, host, port, prefix, key) {
+  if (!(this instanceof Socket)) return new Socket(secure, host, port, prefix, key);
 
   EventEmitter.call(this);
 
@@ -13,8 +13,8 @@ function Socket(secure, host, port, key) {
 
   var httpProtocol = secure ? 'https://' : 'http://';
   var wsProtocol = secure ? 'wss://' : 'ws://';
-  this._httpUrl = httpProtocol + host + ':' + port + '/' + key;
-  this._wsUrl = wsProtocol + host + ':' + port + '/peerjs?key=' + key;
+  this._httpUrl = httpProtocol + host + ':' + port + prefix + key;
+  this._wsUrl = wsProtocol + host + ':' + port + prefix + 'peerjs?key=' + key;
 }
 
 util.inherits(Socket, EventEmitter);


### PR DESCRIPTION
This options add a a prefoix to build paths. It's default to '/'. It's
useful when you're using peerjs behind a proxy or with another server.

fix #89
