### PR TITLE
Removed uneccessary global variable in example chat

### DIFF
--- a/examples/chat.html
+++ b/examples/chat.html
@@ -106,7 +106,7 @@ $(document).ready(function() {
 
   // Connect to a peer
   $('#connect').click(function() {
-    requestedPeer = $('#rid').val();
+    var requestedPeer = $('#rid').val();
     if (!connectedPeers[requestedPeer]) {
       // Create 2 connections, one labelled chat and another labelled file.
       var c = peer.connect(requestedPeer, {


### PR DESCRIPTION
This can cause issues when copy/pasting into a new project with jshint and is generally considered bad practice.
