### PR TITLE
Allow an external adapter.js to be used

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,3 +1,3 @@
-exports.RTCSessionDescription = RTCSessionDescription || window.mozRTCSessionDescription || window.RTCSessionDescription;
-exports.RTCPeerConnection = RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection || window.RTCPeerConnection;
-exports.RTCIceCandidate = RTCIceCandidate || window.mozRTCIceCandidate || window.RTCIceCandidate;
+exports.RTCSessionDescription = window.RTCSessionDescription || window.mozRTCSessionDescription;
+exports.RTCPeerConnection = window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
+exports.RTCIceCandidate = window.RTCIceCandidate || window.mozRTCIceCandidate;


### PR DESCRIPTION
To default to the standard adapter.js.
