### PR TITLE
Expose connection token in Peer options

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -22,6 +22,7 @@ function Peer(id, options) {
     port: util.CLOUD_PORT,
     key: 'peerjs',
     path: '/',
+    token: util.randomToken(),
     config: util.defaultConfig
   }, options);
   this.options = options;
@@ -150,7 +151,7 @@ Peer.prototype._retrieveId = function(cb) {
 Peer.prototype._initialize = function(id) {
   var self = this;
   this.id = id;
-  this.socket.start(this.id);
+  this.socket.start(this.id, this.options.token);
 }
 
 /** Handles messages from the server. */

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -21,10 +21,9 @@ util.inherits(Socket, EventEmitter);
 
 
 /** Check in with ID or get one from server. */
-Socket.prototype.start = function(id) {  
+Socket.prototype.start = function(id, token) {
   this.id = id;
 
-  var token = util.randomToken();
   this._httpUrl += '/' + id + '/' + token;
   this._wsUrl += '&id='+id+'&token='+token;
 


### PR DESCRIPTION
Hi there,

At [BitPay](https://bitpay.com/) we are using PeerJS to build a serverless multi-signature bitcoin wallet, called [Copay](https://github.com/bitpay/copay).

Since each wallet have their own ID, which is used as the Peer ID, we have to provide a resilient way for reconnecting the user after a sudden disconnection. As you may be aware **it's not always possible** to have a graceful disconnection - sending a 'disconnect' message -, therefore the user must wait until the server times out to connect again with the same ID.

In this pull request we expose the server's connection token in the Peer options object in order to offer a way to store it and later reestablish the communication gracefully.

All the comments and suggestions are welcome. Btw, thanks for building such a good project.
