### PR TITLE
fix for memory leak in dataconnection.js

### DIFF
--- a/lib/dataconnection.js
+++ b/lib/dataconnection.js
@@ -118,12 +118,13 @@ DataConnection.prototype._handleDataMessage = function(e) {
     chunkInfo.count += 1;
 
     if (chunkInfo.total === chunkInfo.count) {
+      
+      // free up memory before making the recursive call to _handleDataMessage()
+      delete this._chunkedData[id];
+      
       // We've received all the chunks--time to construct the complete data.
       data = new Blob(chunkInfo.data);
       this._handleDataMessage({data: data});
-
-      // We can also just delete the chunks now.
-      delete this._chunkedData[id];
     }
 
     this._chunkedData[id] = chunkInfo;


### PR DESCRIPTION
Issue: https://github.com/peers/peerjs/issues/200

After completing a large file transfer, it seems like the `_chunkedData` object is not being cleared frequently enough, and so it accumulates data and eats up memory. I think the issue is due to the fact that `delete this._chunkedData[id];` is executed after the recursive call to `_handleDataMessage()`.

To fix, execute `delete this._chunkedData[id];` before the recursive call to `_handleDataMessage()` to free up memory and prevent `_chunkedData` from accumulating a bunch of data.
