### PR TITLE
Added heartbeat to keep the socket open

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -24,6 +24,7 @@ function Peer(id, options) {
     path: '/',
     token: util.randomToken(),
     config: util.defaultConfig
+    heartbeat: 25 * 1000
   }, options);
   this.options = options;
   // Detect relative URL host.
@@ -72,7 +73,10 @@ function Peer(id, options) {
     return;
   }
   //
-
+  
+  // Heartbeat to prevent idle connection closure
+  if(options.heartbeat) this._initializeHeartbeat();
+  
   // States.
   this.destroyed = false; // Connections have been killed
   this.disconnected = false; // Connection to PeerServer killed but P2P connections still active
@@ -422,6 +426,29 @@ Peer.prototype.disconnect = function() {
       self.id = null;
     }
   });
+}
+
+/**
+ * Sends a heartbeat message to keep the socket from idling
+ * Heart beat starts and stops on open/disconnected events
+ */
+Peer.prototype._initializeHeartbeat = function(){
+  var self = this;
+  var heartbeat = this.options.heartbeat;
+  var interval = null;
+  this.on('open',function(){
+    interval = setInterval(self._heartbeat.bind(self),heartbeat);
+  });
+  this.on('disconnected',function(){
+    clearInterval(interval);
+  });
+}
+
+/**
+ * If the connection is open, send a heartbeat to the server
+ */
+Peer.prototype._heartbeat = function(){
+  if(this.open) this.socket.send({type:'HEARTBEAT'});
 }
 
 /** Attempts to reconnect with the same ID. */


### PR DESCRIPTION
When the Peer object is initialized, it'll optionally listen to the `open` and `disconnected` events in order to send a message of type `HEARTBEAT` to the server while the connection is open. It automatically stops sending messages when on disconnect.

This adds a new heartbeat option which can be used to either set the heartbeat interval or disable the heartbeat with a falsy value.