### PR TITLE
Adds option to specify the websocket port

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -106,7 +106,7 @@ util.inherits(Peer, EventEmitter);
 // websockets.)
 Peer.prototype._initializeServerConnection = function() {
   var self = this;
-  this.socket = new Socket(this.options.secure, this.options.host, this.options.port, this.options.path, this.options.key);
+  this.socket = new Socket(this.options.secure, this.options.host, this.options.port, this.options.path, this.options.key, this.options.wsport);
   this.socket.on('message', function(data) {
     self._handleMessage(data);
   });

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -5,8 +5,10 @@ var EventEmitter = require('eventemitter3');
  * An abstraction on top of WebSockets and XHR streaming to provide fastest
  * possible connection for peers.
  */
-function Socket(secure, host, port, path, key) {
-  if (!(this instanceof Socket)) return new Socket(secure, host, port, path, key);
+function Socket(secure, host, port, path, key, wsport) {
+  if (!(this instanceof Socket)) return new Socket(secure, host, port, path, key, wsport);
+
+  wsport = wsport || port;
 
   EventEmitter.call(this);
 
@@ -17,7 +19,7 @@ function Socket(secure, host, port, path, key) {
   var httpProtocol = secure ? 'https://' : 'http://';
   var wsProtocol = secure ? 'wss://' : 'ws://';
   this._httpUrl = httpProtocol + host + ':' + port + path + key;
-  this._wsUrl = wsProtocol + host + ':' + port + path + 'peerjs?key=' + key;
+  this._wsUrl = wsProtocol + host + ':' + wsport + path + 'peerjs?key=' + key;
 }
 
 util.inherits(Socket, EventEmitter);


### PR DESCRIPTION
- Adds wsport as an option for Peer

Some deployment servers require the use of a distinct port for ws connections (OpenShift, to name one)

It might makes more sense to pass the options object in to Socket instead of so many parameters, what do you think? It could enable the possibility to extend the socket functionality further in the future.
