### PR TITLE
Check for pc.readyState undefined prior to negotiator cleanup

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -208,7 +208,7 @@ Negotiator.cleanup = function(connection) {
 
   var pc = connection.pc;
 
-  if (!!pc && (pc.readyState !== 'closed' || pc.signalingState !== 'closed')) {
+  if (!!pc && ((pc.readyState && pc.readyState !== 'closed') || pc.signalingState !== 'closed')) {
     pc.close();
     connection.pc = null;
   }


### PR DESCRIPTION
When a client's computer goes to sleep the peer connection is disconnected but isn't closed properly; this leads to a situation where pc.readyState is `undefined` when the computer wakes up. The current conditional checks for `pc.readyState !== 'closed'` and so when it's `undefined` the conditional is true and `pc.close()` is called on a disconnected session; `pc.close()` then throws an error which interferes with subsequent attempts to reconnect. This PR just checks for `pc.readyState` before checking for `pc.readyState !== 'closed'`.
