### PR TITLE
Add support for peer discovery .

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -181,6 +181,10 @@ Peer.prototype._handleMessage = function(message) {
       this.emit('open', this.id);
       this.open = true;
       break;
+    case 'DISCOVERY': // New peer connection to the server is open & signal discovery.
+      this.emit('discovery', payload.id);
+      this.open = true;
+      break;
     case 'ERROR': // Server error.
       this._abort('server-error', payload.msg);
       break;


### PR DESCRIPTION
Add an handle message of type 'discovery'

Other peers that connect to signal server will be able to config peer to be discovered by other connected peer , that way , other peer can register to .on('discovery', ... ) and get the new peer and connect to it .
this removes the needs to send the new peer by other means of exchange, such as opening another socket .