### PR TITLE
deactivate negotationneeded to avoid breaking in Chrome 66

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -93,7 +93,7 @@ var util = {
 
     var binaryBlob = false;
     var sctp = false;
-    var onnegotiationneeded = !!window.webkitRTCPeerConnection;
+    var onnegotiationneeded = false;
 
     var pc, dc;
     try {
@@ -138,6 +138,7 @@ var util = {
 
     // FIXME: this is not great because in theory it doesn't work for
     // av-only browsers (?).
+    /*
     if (!onnegotiationneeded && data) {
       // sync default check.
       var negotiationPC = new RTCPeerConnection(defaultConfig, {optional: [{RtpDataChannels: true}]});
@@ -154,6 +155,7 @@ var util = {
         negotiationPC.close();
       }, 1000);
     }
+    */
 
     if (pc) {
       pc.close();


### PR DESCRIPTION
this broke with Chrome 66 because of
    https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/discuss-webrtc/Qxj38DwiJPU/5eCOPWvwBgAJ
and negotiationneeded being generally weird in Chrome.

Given the state of the project I doubt this will get merged but it might extend the lifetime for someone long enough to migrate away :-|