### PR TITLE
remove onnegotiationneeded

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -48,9 +48,7 @@ Negotiator.startConnection = function(connection, options) {
       connection.initialize(dc);
     }
 
-    if (!util.supports.onnegotiationneeded) {
-      Negotiator._makeOffer(connection);
-    }
+    Negotiator._makeOffer(connection);
   } else {
     Negotiator.handleSDP("OFFER", connection, options.sdp);
   }
@@ -174,19 +172,6 @@ Negotiator._setupListeners = function(connection, pc, pc_id) {
 
   // Fallback for older Chrome impls.
   pc.onicechange = pc.oniceconnectionstatechange;
-
-  // ONNEGOTIATIONNEEDED (Chrome)
-  util.log("Listening for `negotiationneeded`");
-  pc.onnegotiationneeded = function() {
-    util.log("`negotiationneeded` triggered");
-    if (pc.signalingState == "stable") {
-      Negotiator._makeOffer(connection);
-    } else {
-      util.log(
-        "onnegotiationneeded triggered when not stable. Is another connection being established?"
-      );
-    }
-  };
 
   // DATACONNECTION.
   util.log("Listening for data channel");


### PR DESCRIPTION
stops using onnegotiationneeded to create an offer.
This is wrong in the case of the answering peer and gets
triggered twice in Chrome due to bugs

checked that the videochat and datachannel still work and chrome://webrtc-internals flows look good (see [here](https://testrtc.com/webrtc-api-trace/) for a description how to read the trace)

@kidandcat I think this should work better than #426. Please take a look