### PR TITLE
Upgrade type definitions for TypeScript 3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,6 @@
 // Original definitions by Toshiya Nakakura <https://github.com/nakakura>
 // at https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="webrtc" />
-
 export = Peer;
 
 declare class Peer {
@@ -135,7 +133,7 @@ declare namespace Peer {
         port?: number;
         path?: string;
         secure?: boolean;
-        config?: RTCPeerConnectionConfig;
+        config?: RTCConfiguration;
         debug?: number;
     }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "mocha": "*"
   },
   "dependencies": {
-    "@types/webrtc": "0.0.21",
     "eventemitter3": "^0.1.5",
     "js-binarypack": "0.0.9",
     "opencollective": "^1.0.3",


### PR DESCRIPTION
Typescript now has definitions for WebRTC APIs built in. The `@types/webrtc` package now causes a bunch of errors from conflicts, so I removed that dependency, and then changed the reference `RTCPeerConnectionConfig` to its current name, `RTCConfiguration` ([they were aliases to the same thing in `@types/webrtc`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/176374804aeda5431e2fcef3a849d91425ae7ee9/types/webrtc/RTCPeerConnection.d.ts#L225); now TypeScript only has the latter).