### PR TITLE
#453 Change deprecated onaddstream to ontrack

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -186,15 +186,10 @@ Negotiator._setupListeners = function(connection, pc, pc_id) {
 
   // MEDIACONNECTION.
   util.log("Listening for remote stream");
-  pc.onaddstream = function(evt) {
+  pc.ontrack = function(evt) {
     util.log("Received remote stream");
-    var stream = evt.stream;
+    var stream = evt.streams[0];
     var connection = provider.getConnection(peerId, connectionId);
-    // 10/10/2014: looks like in Chrome 38, onaddstream is triggered after
-    // setting the remote description. Our connection object in these cases
-    // is actually a DATA connection, so addStream fails.
-    // TODO: This is hopefully just a temporary fix. We should try to
-    // understand why this is happening.
     if (connection.type === "media") {
       connection.addStream(stream);
     }


### PR DESCRIPTION
Have tested this locally between latest Chrome & Firefox, works fine with video streams.

Should I also make a build? It will update `webrtc-adapter` as well, to the (recently released) latest 6.4.0.

I've actually tried to build, but my build system (Mac OS) changes CRLF line endings and produces a giant diff... Not sure you want this, so refrained from pushing the `dist/peer.js` and `dist/peer.min.js`.

Fixes #453