### PR TITLE
Add missing declaration of index

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -266,6 +266,7 @@ export const util = {
   chunk: function(bl) {
     var chunks = [];
     var size = bl.size;
+    var index;
     var start = (index = 0);
     var total = Math.ceil(size / util.chunkedMTU);
     while (start < size) {


### PR DESCRIPTION
Previously client was failing when sending large messages, chunking was failing with index not defined.

Example of code that was failing:

var x = "1234567890";
var iterations = 7;
for (var i = 0; i < iterations; i++) {
  x += x+x;
}

conn.send({data:x});