### PR TITLE
Move standardjs to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "^1.1.2",
     "mocha": "*",
     "selenium-standalone": "^6.15.3",
+    "standard": "^12.0.1",
     "standard-version": "^4.4.0",
     "typescript": "^3.3.3"
   },
@@ -51,7 +52,6 @@
     "peerjs": "^0.3.20",
     "react": "^16.8.1",
     "reliable": "git+https://github.com/michelle/reliable.git",
-    "standard": "^12.0.1",
     "webrtc-adapter": "^6.3.2"
   },
   "collective": {


### PR DESCRIPTION
Moving standard into dev dependencies. This change addresses https://github.com/peers/peerjs/issues/489

Thank you!