### PR TITLE
Allow 'key' option to be configurable again

### DIFF
--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -28,12 +28,12 @@ export function Peer(id, options): void {
       host: util.CLOUD_HOST,
       port: util.CLOUD_PORT,
       path: "/",
+      key: "peerjs",
       token: util.randomToken(),
       config: util.defaultConfig
     },
     options
   );
-  options.key = "peerjs";
   this.options = options;
   // Detect relative URL host.
   if (options.host === "/") {


### PR DESCRIPTION
According to our [discussion](https://github.com/peers/peerjs/commit/73d9173c3ee15d49862d22c19c87c6c70465edab#r32795894) I am proposing to reenable the `key` option to be configurable.

For custom server implementations this might be useful to have. 
