### PR TITLE
Add timeout as option to dataconnection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,7 @@ declare namespace Peer {
     metadata?: any;
     serialization?: string;
     reliable?: boolean;
+    heartbeatInterval?: number;
   }
 
   interface CallOption {

--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -62,3 +62,7 @@ export enum ServerMessageType {
   Expire = "EXPIRE" // The offer sent to a peer has expired without response.
 
 }
+
+export enum SocketSpecialMessagePrefix {
+  Heartbeat = "HEARTBEAT_",
+}

--- a/lib/negotiator.ts
+++ b/lib/negotiator.ts
@@ -217,7 +217,8 @@ export class Negotiator {
             ...payload,
             label: dataConnection.label,
             reliable: dataConnection.reliable,
-            serialization: dataConnection.serialization
+            serialization: dataConnection.serialization,
+            heartbeatInterval: dataConnection.heartbeatInterval,
           };
         }
 

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -266,7 +266,8 @@ export class Peer extends EventEmitter {
             metadata: payload.metadata,
             label: payload.label,
             serialization: payload.serialization,
-            reliable: payload.reliable
+            reliable: payload.reliable,
+            heartbeatInterval: payload.heartbeatInterval,
           });
           this._addConnection(peerId, connection);
           this.emit(PeerEventType.Connection, connection);


### PR DESCRIPTION
This will add a new option to the datachannel to enable a timeout function (#769).

This works by sending a special message every N seconds and automatically close the channel if the message from the other end was not received within N*2 seconds. The receiver does not emit the special message to the user.

This implementation works but nothing has been added to the documentation. After a maintainer confirms, that this is the right way to do it, I'll add documentation and tests.