### PR TITLE
Added Raw serialization type

### DIFF
--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -39,7 +39,8 @@ export enum PeerErrorType {
 export enum SerializationType {
   Binary = "binary",
   BinaryUTF8 = "binary-utf8",
-  JSON = "json"
+  JSON = "json",
+  Raw = "raw"
 }
 
 export enum SocketEventType {


### PR DESCRIPTION
This PR introduce a `raw` serialization type which allow to bypass the `binarypack` serialization mechanism and delegate it to the user. 

With this modification I have been able to exchange messages with a [server-side port of peer](https://github.com/muka/peerjs-go).

Porting binarypack to other languages is challenging but using raw byte exchange or other serialization libraries (like proto buffer or avro) would be significantly easier.

I tried to implement test but seems on node side is not possible to go much further testing data connections

This mark also a progress in #759 for interoperability direction 

Thank you