### PR TITLE
fix: add token to PeerJSOption type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,7 @@ declare namespace Peer {
     port?: number;
     path?: string;
     secure?: boolean;
+    token?: string;
     config?: RTCConfiguration;
     debug?: number;
   }


### PR DESCRIPTION
This PR add `token` option to PeerJSOption in type definition file.

This closes #897 