### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -145,7 +145,7 @@ export const util = new class {
   randomToken(): string {
     return Math.random()
       .toString(36)
-      .substr(2);
+      .slice(2);
   }
 
   isSecure(): boolean {


### PR DESCRIPTION

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.