### PR TITLE
add missing type exports

### DIFF
--- a/lib/exports.ts
+++ b/lib/exports.ts
@@ -10,6 +10,16 @@ export type {
 export type { UtilSupportsObj } from "./util";
 export type { DataConnection } from "./dataconnection";
 export type { MediaConnection } from "./mediaconnection";
+export type { LogLevel } from './logger'
+export type {
+	ConnectionEventType,
+	ConnectionType,
+	PeerEventType,
+	PeerErrorType,
+	SerializationType,
+	SocketEventType,
+	ServerMessageType,
+} from "./enums";
 
 export { Peer, util };
 export default Peer;


### PR DESCRIPTION
With a fresh angular project created using `ng new peerjs-test` and the installing the peerjs library `npm install --save peerjs` trying to import the library via `import {Peer} from 'peerjs'` results in the following error.
```
Error: ../peerjs/dist/types.d.ts:49:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

49 enum LogLevel {
``` 

adding the missing types to the exports.ts causes them to be exported in the resulting `types.d.ts` file which resolves this build issue.