### PR TITLE
Fix MediaStream remote close by using an aux RTCDataChannel

### DIFF
--- a/lib/mediaconnection.ts
+++ b/lib/mediaconnection.ts
@@ -23,6 +23,7 @@ export class MediaConnection extends BaseConnection<MediaConnectionEvents> {
 	private _negotiator: Negotiator<MediaConnectionEvents, MediaConnection>;
 	private _localStream: MediaStream;
 	private _remoteStream: MediaStream;
+	private _dc: RTCDataChannel;
 
 	get type() {
 		return ConnectionType.Media;
@@ -33,6 +34,10 @@ export class MediaConnection extends BaseConnection<MediaConnectionEvents> {
 	}
 	get remoteStream(): MediaStream {
 		return this._remoteStream;
+	}
+
+	get dataChannel(): RTCDataChannel {
+		return this._dc;
 	}
 
 	constructor(peerId: string, provider: Peer, options: any) {
@@ -51,6 +56,31 @@ export class MediaConnection extends BaseConnection<MediaConnectionEvents> {
 				originator: true,
 			});
 		}
+	}
+
+	/** Called by the Negotiator when the DataChannel is ready. */
+	initialize(dc: RTCDataChannel): void {
+		this._dc = dc;
+		this._configureDataChannel();
+	}
+
+	private _configureDataChannel(): void {
+		if (!util.supports.binaryBlob || util.supports.reliable) {
+			this.dataChannel.binaryType = "arraybuffer";
+		}
+
+		this.dataChannel.onopen = () => {
+			logger.log(`DC#${this.connectionId} dc connection success`);
+		};
+
+		this.dataChannel.onmessage = (e) => {
+			logger.log(`DC#${this.connectionId} dc onmessage:`, e.data);
+		};
+
+		this.dataChannel.onclose = () => {
+			logger.log(`DC#${this.connectionId} dc closed for:`, this.peer);
+			this.close();
+		};
 	}
 
 	addStream(remoteStream) {

--- a/lib/negotiator.ts
+++ b/lib/negotiator.ts
@@ -38,6 +38,12 @@ export class Negotiator<
 					config,
 				);
 				dataConnection.initialize(dataChannel);
+			} else if (this.connection.type === ConnectionType.Media) {
+				const mediaConnection = <MediaConnection>(<unknown>this.connection);
+				const dataChannel = peerConnection.createDataChannel(
+					mediaConnection.connectionId,
+				);
+				mediaConnection.initialize(dataChannel);
 			}
 
 			this._makeOffer();
@@ -180,6 +186,14 @@ export class Negotiator<
 		if (this.connection.type === ConnectionType.Data) {
 			const dataConnection = <DataConnection>(<unknown>this.connection);
 			const dataChannel = dataConnection.dataChannel;
+
+			if (dataChannel) {
+				dataChannelNotClosed =
+					!!dataChannel.readyState && dataChannel.readyState !== "closed";
+			}
+		} else if (this.connection.type === ConnectionType.Media) {
+			const mediaConnection = <MediaConnection>(<unknown>this.connection);
+			const dataChannel = mediaConnection.dataChannel;
 
 			if (dataChannel) {
 				dataChannelNotClosed =


### PR DESCRIPTION
### Problem

`MediaConnection.close()` doesn't propagate the `close` event to the remote peer.

### Solution

The proposed solution uses a similar approach to the `DataConnection`, where an aux data channel is created for the connection.
This way, when we `MediaConnection.close()` the data channel will be closed and the `close` signal will be propagated to the remote peer.

#### Notes

I was not sure if there was another cleaner way of achieving this, without the extra data channel, but this seems to work pretty well (at least until a better solution comes up).