### PR TITLE
Add support for defining WebSocket `protocol` to use with Peer instance

### DIFF
--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -28,7 +28,7 @@ class PeerOptions implements PeerJSOption {
 	config?: any;
 	secure?: boolean;
 	pingInterval?: number;
-  protocol?: string | string[];
+	protocol?: string | string[];
 	referrerPolicy?: ReferrerPolicy;
 	logFunction?: (logLevel: LogLevel, ...rest: any[]) => void;
 }

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -28,6 +28,7 @@ class PeerOptions implements PeerJSOption {
 	config?: any;
 	secure?: boolean;
 	pingInterval?: number;
+  protocol?: string | string[];
 	referrerPolicy?: ReferrerPolicy;
 	logFunction?: (logLevel: LogLevel, ...rest: any[]) => void;
 }

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -22,7 +22,7 @@ export class Socket extends EventEmitter {
 		path: string,
 		key: string,
 		private readonly pingInterval: number = 5000,
-    private readonly protocol: string | string[] | undefined = undefined,
+		private readonly protocol: string | string[] | undefined = undefined,
 	) {
 		super();
 

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -22,6 +22,7 @@ export class Socket extends EventEmitter {
 		path: string,
 		key: string,
 		private readonly pingInterval: number = 5000,
+    private readonly protocol: string | string[] | undefined = undefined,
 	) {
 		super();
 
@@ -39,7 +40,7 @@ export class Socket extends EventEmitter {
 			return;
 		}
 
-		this._socket = new WebSocket(wsUrl + "&version=" + version);
+		this._socket = new WebSocket(wsUrl + "&version=" + version, this.protocol);
 		this._disconnected = false;
 
 		this._socket.onmessage = (event) => {


### PR DESCRIPTION
This PR adds a `protocol` option to the `PeerOptions`, that users can use to for instance choose different versions of Peer servers, and more.