### PR TITLE
fix(datachannel): sending order is now preserved correctly

### DIFF
--- a/e2e/datachannel/serialization.spec.ts
+++ b/e2e/datachannel/serialization.spec.ts
@@ -25,10 +25,11 @@ describe("DataChannel:Default", () => {
 		await P.init();
 	});
 	it("should transfer numbers", serializationTest("./numbers.js"));
-	/** ordering bug: chunked string not in order */
-	// it('should transfer strings', serializationTest("./strings.js"))
+	it("should transfer strings", serializationTest("./strings.js"));
 	it("should transfer objects", serializationTest("./objects.js"));
 	it("should transfer arrays", serializationTest("./arrays.js"));
-	/** can't send bug */
-	// it('should transfer typed arrays / array buffers', serializationTest("./arraybuffers.js"))
+	it(
+		"should transfer typed arrays / array buffers",
+		serializationTest("./arraybuffers.js"),
+	);
 });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -131,10 +131,10 @@ export class Util {
 	private _dataCount: number = 1;
 
 	chunk(
-		blob: Blob,
-	): { __peerData: number; n: number; total: number; data: Blob }[] {
+		blob: ArrayBuffer,
+	): { __peerData: number; n: number; total: number; data: ArrayBuffer }[] {
 		const chunks = [];
-		const size = blob.size;
+		const size = blob.byteLength;
 		const total = Math.ceil(size / util.chunkedMTU);
 
 		let index = 0;
@@ -208,3 +208,16 @@ export class Util {
  * :::
  */
 export const util = new Util();
+export function concatArrayBuffers(bufs: Uint8Array[]) {
+	let size = 0;
+	for (const buf of bufs) {
+		size += buf.byteLength;
+	}
+	const result = new Uint8Array(size);
+	let offset = 0;
+	for (const buf of bufs) {
+		result.set(buf, offset);
+		offset += buf.byteLength;
+	}
+	return result;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@swc/helpers": "^0.5.0",
 				"eventemitter3": "^4.0.7",
-				"peerjs-js-binarypack": "1.0.2",
+				"peerjs-js-binarypack": "^2.0.0",
 				"webrtc-adapter": "^8.0.0"
 			},
 			"devDependencies": {
@@ -14550,9 +14550,16 @@
 			}
 		},
 		"node_modules/peerjs-js-binarypack": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-1.0.2.tgz",
-			"integrity": "sha512-/5OcAiSN8R/Hd1YCGQ+EcBtq5S10BZekZ85Cmwzf1DYM34y6RYXpRxRTCYL1bQH3GXNBr/tQftMKUw4UNb+ZMg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.0.0.tgz",
+			"integrity": "sha512-wu+L0Qeg4IH2DXm3B6xKP5ODeCIovwEEO/Fu3MVqApPQeVLzSdZpFzQzPobh+sdhUWMQGEO7YxHeiwpPngLjqQ==",
+			"engines": {
+				"node": ">= 14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/peer"
+			}
 		},
 		"node_modules/pend": {
 			"version": "1.2.0",
@@ -28503,9 +28510,9 @@
 			}
 		},
 		"peerjs-js-binarypack": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-1.0.2.tgz",
-			"integrity": "sha512-/5OcAiSN8R/Hd1YCGQ+EcBtq5S10BZekZ85Cmwzf1DYM34y6RYXpRxRTCYL1bQH3GXNBr/tQftMKUw4UNb+ZMg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.0.0.tgz",
+			"integrity": "sha512-wu+L0Qeg4IH2DXm3B6xKP5ODeCIovwEEO/Fu3MVqApPQeVLzSdZpFzQzPobh+sdhUWMQGEO7YxHeiwpPngLjqQ=="
 		},
 		"pend": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
 	"dependencies": {
 		"@swc/helpers": "^0.5.0",
 		"eventemitter3": "^4.0.7",
-		"peerjs-js-binarypack": "1.0.2",
+		"peerjs-js-binarypack": "^2.0.0",
 		"webrtc-adapter": "^8.0.0"
 	}
 }


### PR DESCRIPTION
This upgrades `binarypack` to version 2.

`pack` now returns `ArrayBuffer`s which can be sent over all data channel types without asynchronous conversion.
This implementation is also much faster than version 1.

Closes #746