### PR TITLE
test(e2e): add test for "ID-TAKEN" twice in a row

### DIFF
--- a/e2e/peer/id-taken.html
+++ b/e2e/peer/id-taken.html
@@ -20,24 +20,37 @@
 			const messages = document.getElementById("messages");
 			const errorMessage = document.getElementById("error-message");
 
-			new Peer()
+			// Peer A should be created without an error
+			const peerA = new Peer()
 				.once(
 					"error",
-					(error) => void (errorMessage.textContent = JSON.stringify(error)),
+					(err) => (errorMessage.textContent += JSON.stringify(err)),
 				)
-				.once("open", (id) =>
-					new Peer(id).once(
-						"error",
-						(error) => {
-							messages.textContent = JSON.stringify(error);
-							// At the time of writng the second one succeeds for some reason.
-							new Peer(id).once(
-								"error",
-								(error) => void (errorMessage.textContent = JSON.stringify(error)),
-							);
-						},
-					),
-				);
+				.once("open", (id) => {
+					// Create 10 new `Peer`s that will try to steel A's id
+					let peers_try_to_take = Array.from(
+						{ length: 10 },
+						(_, i) =>
+							new Promise((resolve, reject) =>
+								new Peer(id)
+									.once("open", () =>
+										reject(`Peer ${i} failed! Connection got established.`),
+									)
+									.once("error", (error) => {
+										if (error.type === "unavailable-id") {
+											resolve(`ID already taken. (${i})`);
+										} else {
+											reject(error);
+										}
+									}),
+							),
+					);
+					Promise.all(peers_try_to_take)
+						.then(() => (messages.textContent = "No ID takeover"))
+						.catch(
+							(error) => (errorMessage.textContent += JSON.stringify(error)),
+						);
+				});
 		</script>
 	</body>
 </html>

--- a/e2e/peer/peer.spec.ts
+++ b/e2e/peer/peer.spec.ts
@@ -4,8 +4,7 @@ import { browser, expect } from "@wdio/globals";
 describe("Peer", () => {
 	it("should emit an error, when the ID is already taken", async () => {
 		await P.open("id-taken");
-		await P.waitForMessage('{"type":"unavailable-id"}');
-		await P.waitForMessage('{"type":"unavailable-id"}');
+		await P.waitForMessage("No ID takeover");
 		expect(await P.errorMessage.getText()).toBe("");
 	});
 	it("should emit an error, when the server is unavailable", async () => {


### PR DESCRIPTION
See https://github.com/peers/peerjs/issues/180#issuecomment-1689993774
Follow-up to 1005bdf012