### PR TITLE
fix: convert `Blob`s to `ArrayBuffer`s during `.send()`

### DIFF
--- a/e2e/datachannel/blobs.js
+++ b/e2e/datachannel/blobs.js
@@ -1,0 +1,21 @@
+import { commit_data } from "../data.js";
+import { expect } from "https://esm.sh/v126/chai@4.3.7/X-dHMvZXhwZWN0/es2021/chai.bundle.mjs";
+
+const Encoder = new TextEncoder();
+
+/** @param {unknown[]} received */
+export const check = (received) => {
+	expect(received).to.be.an("array").with.lengthOf(commit_data.length);
+	const commits_as_arraybuffer = commit_data.map(
+		(blob) => Encoder.encode(JSON.stringify(blob)).buffer,
+	);
+	expect(received).to.deep.equal(commits_as_arraybuffer);
+};
+/**
+ * @param {import("../peerjs").DataConnection} dataConnection
+ */
+export const send = async (dataConnection) => {
+	for (const commit of commit_data) {
+		await dataConnection.send(new Blob([JSON.stringify(commit)]));
+	}
+};

--- a/e2e/datachannel/files.js
+++ b/e2e/datachannel/files.js
@@ -1,0 +1,25 @@
+import { commit_data } from "../data.js";
+import { expect } from "https://esm.sh/v126/chai@4.3.7/X-dHMvZXhwZWN0/es2021/chai.bundle.mjs";
+
+const Encoder = new TextEncoder();
+
+/** @param {unknown[]} received */
+export const check = (received) => {
+	expect(received).to.be.an("array").with.lengthOf(commit_data.length);
+	const commits_as_arraybuffer = commit_data.map(
+		(blob) => Encoder.encode(JSON.stringify(blob)).buffer,
+	);
+	expect(received).to.deep.equal(commits_as_arraybuffer);
+};
+/**
+ * @param {import("../peerjs").DataConnection} dataConnection
+ */
+export const send = async (dataConnection) => {
+	for (const commit of commit_data) {
+		await dataConnection.send(
+			new File([JSON.stringify(commit)], "commit.txt", {
+				type: "dummy/data",
+			}),
+		);
+	}
+};

--- a/e2e/datachannel/serialization.js
+++ b/e2e/datachannel/serialization.js
@@ -82,11 +82,11 @@ const serialization = params.get("serialization");
 		}
 	});
 
-	sendBtn.addEventListener("click", () => {
+	sendBtn.addEventListener("click", async () => {
 		dataConnection.once("error", (err) => {
 			errorMessage.innerText = err.toString();
 		});
-		send(dataConnection);
+		await send(dataConnection);
 		dataConnection.close({ flush: true });
 		messages.textContent = "Sent!";
 	});

--- a/e2e/datachannel/serialization_binary.spec.ts
+++ b/e2e/datachannel/serialization_binary.spec.ts
@@ -33,6 +33,18 @@ describe("DataChannel:Binary", () => {
 		2,
 	);
 	it(
+		"should transfer Blobs",
+		serializationTest("./blobs", "binary"),
+		jasmine.DEFAULT_TIMEOUT_INTERVAL,
+		2,
+	);
+	it(
+		"should transfer Files",
+		serializationTest("./files", "binary"),
+		jasmine.DEFAULT_TIMEOUT_INTERVAL,
+		2,
+	);
+	it(
 		"should transfer arrays",
 		serializationTest("./arrays", "binary"),
 		jasmine.DEFAULT_TIMEOUT_INTERVAL,

--- a/lib/dataconnection/BufferedConnection/BinaryPack.ts
+++ b/lib/dataconnection/BufferedConnection/BinaryPack.ts
@@ -79,6 +79,11 @@ export class BinaryPack extends BufferedConnection {
 		data: Packable,
 		chunked: boolean,
 	): void | Promise<void> {
+		if (data instanceof Blob) {
+			return data.arrayBuffer().then((buffer) => {
+				this._send(buffer, chunked);
+			});
+		}
 		const blob = pack(data);
 
 		if (!chunked && blob.byteLength > this.chunker.chunkedMTU) {

--- a/lib/dataconnection/DataConnection.ts
+++ b/lib/dataconnection/DataConnection.ts
@@ -124,7 +124,7 @@ export abstract class DataConnection extends BaseConnection<
 		super.emit("close");
 	}
 
-	protected abstract _send(data: any, chunked: boolean): void;
+	protected abstract _send(data: any, chunked: boolean): void | Promise<void>;
 
 	/** Allows user to send data. */
 	public send(data: any, chunked = false) {


### PR DESCRIPTION
BinaryPack 2 can’t pack `Blob`s anymore. Convert them to `ArrayBuffer`s during send.