### PR TITLE
Notification based BufferedDataConnection

### DIFF
--- a/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
+++ b/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
@@ -1,10 +1,13 @@
-
 export interface BinaryPackChunk {
-	__peerData: number
+	id: number
 	n: number
 	total: number
-	data: Uint8Array
+	data: ArrayBuffer
 };
+
+export function isBinaryPackChunk(obj: any): obj is BinaryPackChunk {
+    return typeof obj === 'object' && 'id' in obj;
+}
 
 export class BinaryPackChunker {
 	readonly chunkedMTU = 16300; // The original 60000 bytes setting does not work when sending data from Firefox to Chrome, which is "cut off" after 16384 bytes and delivered individually.
@@ -16,7 +19,7 @@ export class BinaryPackChunker {
 	chunk = (
 		blob: ArrayBuffer,
 	): BinaryPackChunk[] => {
-		const chunks = [];
+		const chunks: BinaryPackChunk[] = [];
 		const size = blob.byteLength;
 		const total = Math.ceil(size / this.chunkedMTU);
 
@@ -27,8 +30,8 @@ export class BinaryPackChunker {
 			const end = Math.min(size, start + this.chunkedMTU);
 			const b = blob.slice(start, end);
 
-			const chunk = {
-				__peerData: this._dataCount,
+			const chunk: BinaryPackChunk = {
+				id: this._dataCount,
 				n: index,
 				data: b,
 				total,
@@ -46,11 +49,11 @@ export class BinaryPackChunker {
 	};
 
 	singleChunk = (blob: ArrayBuffer): BinaryPackChunk => {
-		const __peerData = this._dataCount;
+		const id = this._dataCount;
 		this._dataCount++;
 
 		return {
-			__peerData,
+			id,
 			n: 0,
 			total: 1,
 			data: new Uint8Array(blob),

--- a/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
+++ b/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
@@ -1,3 +1,11 @@
+
+export interface BinaryPackChunk {
+	__peerData: number
+	n: number
+	total: number
+	data: Uint8Array
+};
+
 export class BinaryPackChunker {
 	readonly chunkedMTU = 16300; // The original 60000 bytes setting does not work when sending data from Firefox to Chrome, which is "cut off" after 16384 bytes and delivered individually.
 
@@ -7,7 +15,7 @@ export class BinaryPackChunker {
 
 	chunk = (
 		blob: ArrayBuffer,
-	): { __peerData: number; n: number; total: number; data: Uint8Array }[] => {
+	): BinaryPackChunk[] => {
 		const chunks = [];
 		const size = blob.byteLength;
 		const total = Math.ceil(size / this.chunkedMTU);

--- a/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
+++ b/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
@@ -15,6 +15,10 @@ export class BinaryPackChunker {
 	// Binary stuff
 
 	private _dataCount: number = 1;
+	
+	public get nextID(): number {
+		return this._dataCount;
+	}
 
 	chunk = (
 		blob: ArrayBuffer,

--- a/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
+++ b/lib/dataconnection/BufferedConnection/binaryPackChunker.ts
@@ -44,6 +44,18 @@ export class BinaryPackChunker {
 
 		return chunks;
 	};
+
+	singleChunk = (blob: ArrayBuffer): BinaryPackChunk => {
+		const __peerData = this._dataCount;
+		this._dataCount++;
+
+		return {
+			__peerData,
+			n: 0,
+			total: 1,
+			data: new Uint8Array(blob),
+		};
+	}
 }
 
 export function concatArrayBuffers(bufs: Uint8Array[]) {

--- a/lib/dataconnection/BufferedNotifyConnection.ts
+++ b/lib/dataconnection/BufferedNotifyConnection.ts
@@ -1,0 +1,182 @@
+import { pack, unpack } from "peerjs-js-binarypack";
+import logger from "../logger";
+import { DataConnection } from "./DataConnection";
+import { BinaryPackChunk, BinaryPackChunker, concatArrayBuffers } from "./BufferedConnection/binaryPackChunker";
+
+
+export class BufferedNotifyConnection extends DataConnection {
+    serialization: 'notify';
+    private readonly chunker = new BinaryPackChunker();
+
+    private _chunkedData: {
+        [id: number]: {
+            data: Uint8Array[];
+            count: number;
+            total: number;
+        };
+    } = {};
+
+
+    protected _send(data: any, chunked: boolean): { __peerData: number, total: number } {
+
+        const blob = pack(data);
+
+        if (!chunked && blob.byteLength > this.chunker.chunkedMTU) {
+
+            const blobs = this.chunker.chunk(blob);
+            logger.log(`DC#${this.connectionId} Try to send ${blobs.length} chunks...`);
+
+            for (const blob of blobs) {
+                this._bufferedSend(blob);
+            }
+
+            return { __peerData: blobs[0].__peerData, total: blobs.length };
+        }
+        //We send everything in one chunk
+
+        return { __peerData: 0, total: 1 };
+    }
+
+    private _buffer: BinaryPackChunk[] = [];
+    private _bufferSize = 0;
+    private _buffering = false;
+
+    public get bufferSize(): number {
+        return this._bufferSize;
+    }
+
+    public override _initializeDataChannel(dc: RTCDataChannel) {
+        super._initializeDataChannel(dc);
+        this.dataChannel.binaryType = "arraybuffer";
+        this.dataChannel.addEventListener("message", (e) =>
+            this._handleDataMessage(e),
+        );
+    }
+
+
+    protected _handleDataMessage({ data }: { data: Uint8Array }): void {
+        // Assume we only get BinaryPackChunks
+        const deserializedData = unpack(data);
+
+        // PeerJS specific message
+        const peerData = deserializedData["__peerData"];
+        if (peerData) {
+            if (peerData.type === "close") {
+                this.close();
+                return;
+            }
+
+            if (typeof peerData === "number") {
+                // @ts-ignore
+                this._handleChunk(deserializedData);
+                return;
+            }
+
+        }
+
+        this.emit("data", deserializedData);
+    }
+
+
+    private _handleChunk(data: {
+        __peerData: number;
+        n: number;
+        total: number;
+        data: ArrayBuffer;
+    }): void {
+        const id = data.__peerData;
+        const chunkInfo = this._chunkedData[id] || {
+            data: [],
+            count: 0,
+            total: data.total,
+        };
+
+        chunkInfo.data[data.n] = new Uint8Array(data.data);
+        chunkInfo.count++;
+        this._chunkedData[id] = chunkInfo;
+
+        if (chunkInfo.total === chunkInfo.count) {
+            // Clean up before making the recursive call to `_handleDataMessage`.
+            delete this._chunkedData[id];
+
+            // We've received all the chunks--time to construct the complete data.
+            // const data = new Blob(chunkInfo.data);
+            const data = concatArrayBuffers(chunkInfo.data);
+            this._handleDataMessage({ data });
+        }
+    }
+
+
+    protected _bufferedSend(msg: BinaryPackChunk): void {
+        if (this._buffering || !this._trySend(msg)) {
+            this._buffer.push(msg);
+            this._bufferSize = this._buffer.length;
+        }
+    }
+
+    // Returns true if the send succeeds.
+    private _trySend(msg: BinaryPackChunk): boolean {
+        if (!this.open) {
+            return false;
+        }
+
+        if (this.dataChannel.bufferedAmount > DataConnection.MAX_BUFFERED_AMOUNT) {
+            this._buffering = true;
+            setTimeout(() => {
+                this._buffering = false;
+                this._tryBuffer();
+            }, 50);
+
+            return false;
+        }
+
+        try {
+            // Send notification
+            this.emit("sentChunk", { __peerData: msg.__peerData, n: msg.n });
+            const msgPacked = pack(msg as any);
+            this.dataChannel.send(msgPacked);
+        } catch (e) {
+            logger.error(`DC#:${this.connectionId} Error when sending:`, e);
+            this._buffering = true;
+
+            this.close();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    // Try to send the first message in the buffer.
+    private _tryBuffer(): void {
+        if (!this.open) {
+            return;
+        }
+
+        if (this._buffer.length === 0) {
+            return;
+        }
+
+        const msg = this._buffer[0];
+
+        if (this._trySend(msg)) {
+            this._buffer.shift();
+            this._bufferSize = this._buffer.length;
+            this._tryBuffer();
+        }
+    }
+
+    public override close(options?: { flush?: boolean }) {
+        if (options?.flush) {
+            this.send({
+                __peerData: {
+                    type: "close",
+                },
+            });
+            return;
+        }
+        this._buffer = [];
+        this._bufferSize = 0;
+        super.close();
+    }
+}

--- a/lib/dataconnection/DataConnection.ts
+++ b/lib/dataconnection/DataConnection.ts
@@ -17,7 +17,7 @@ export interface SendData {
 	total: number
 }
 
-export interface ChunkSentNotification extends SendData{
+export interface ChunkSentNotification extends SendData {
 	n: number
 }
 
@@ -140,6 +140,23 @@ export abstract class DataConnection extends BaseConnection<
 		super.emit("close");
 	}
 
+	/**
+	 * @param data 
+	 * @param chunked 
+	 * @returns Returns SendData if datachannel is notification based
+	 * @example
+	 * const res = conn.send(currentMessage);
+	 * if (typeof res === 'object' && 'id' in res) {
+	 * 	conn.on('sentChunk', (chunk) => {
+	 * 		if (chunk.id === res.id) {
+	 * 			console.log('Sent chunk', chunk);
+	 * 			if (chunk.n == res.total -1) {
+	 * 				console.log('Sent last chunk');
+	 * 			}
+	 * 		}
+	 * 	});
+	 * }
+	 */
 	protected abstract _send(data: any, chunked: boolean): void | Promise<void> | SendData;
 
 	/** Allows user to send data. */

--- a/lib/dataconnection/DataConnection.ts
+++ b/lib/dataconnection/DataConnection.ts
@@ -12,8 +12,12 @@ import type { ServerMessage } from "../servermessage";
 import type { EventsWithError } from "../peerError";
 import { randomToken } from "../utils/randomToken";
 
-export interface ChunkSentNotification {
-	__peerData: number,
+export interface SendData {
+	id: number,
+	total: number
+}
+
+export interface ChunkSentNotification extends SendData{
 	n: number
 }
 
@@ -136,7 +140,7 @@ export abstract class DataConnection extends BaseConnection<
 		super.emit("close");
 	}
 
-	protected abstract _send(data: any, chunked: boolean): void;
+	protected abstract _send(data: any, chunked: boolean): void | Promise<void> | SendData;
 
 	/** Allows user to send data. */
 	public send(data: any, chunked = false) {

--- a/lib/dataconnection/DataConnection.ts
+++ b/lib/dataconnection/DataConnection.ts
@@ -12,9 +12,14 @@ import type { ServerMessage } from "../servermessage";
 import type { EventsWithError } from "../peerError";
 import { randomToken } from "../utils/randomToken";
 
+export interface ChunkSentNotification {
+	__peerData: number,
+	n: number
+}
+
 export interface DataConnectionEvents
 	extends EventsWithError<DataConnectionErrorType | BaseConnectionErrorType>,
-		BaseConnectionEvents<DataConnectionErrorType | BaseConnectionErrorType> {
+	BaseConnectionEvents<DataConnectionErrorType | BaseConnectionErrorType> {
 	/**
 	 * Emitted when data is received from the remote peer.
 	 */
@@ -23,6 +28,13 @@ export interface DataConnectionEvents
 	 * Emitted when the connection is established and ready-to-use.
 	 */
 	open: () => void;
+
+	/**
+	 * Emitted when the connection sends out a chunk of data to the remote peer.
+	 * Currently Only implemented by BufferedNotifyConnection.
+	 */
+	sentChunk: (chunk: ChunkSentNotification) => void;
+
 }
 
 /**

--- a/lib/dataconnection/DataConnection.ts
+++ b/lib/dataconnection/DataConnection.ts
@@ -140,26 +140,26 @@ export abstract class DataConnection extends BaseConnection<
 		super.emit("close");
 	}
 
+	protected abstract _send(data: any, chunked: boolean): void;
+
+
 	/**
+	 * Allows user to send data.
 	 * @param data 
 	 * @param chunked 
-	 * @returns Returns SendData if datachannel is notification based
 	 * @example
-	 * const res = conn.send(currentMessage);
-	 * if (typeof res === 'object' && 'id' in res) {
-	 * 	conn.on('sentChunk', (chunk) => {
-	 * 		if (chunk.id === res.id) {
-	 * 			console.log('Sent chunk', chunk);
-	 * 			if (chunk.n == res.total -1) {
-	 * 				console.log('Sent last chunk');
-	 * 			}
-	 * 		}
-	 * 	});
-	 * }
+	 * 
+	 * 	const nextId = conn.nextID;
+	 *	conn.on('sentChunk', (chunk) => {
+	 *		if (chunk.id === nextId) {
+	 *			console.log('Sent chunk', chunk);
+	 *			if (chunk.n == chunk.total - 1) {
+	 *				console.log('Sent last chunk');
+	 *			}
+	 *		}
+	 *	});
+	 *	conn.send(arr);
 	 */
-	protected abstract _send(data: any, chunked: boolean): void | Promise<void> | SendData;
-
-	/** Allows user to send data. */
 	public send(data: any, chunked = false) {
 		if (!this.open) {
 			this.emitError(

--- a/lib/exports.ts
+++ b/lib/exports.ts
@@ -12,7 +12,7 @@ export type {
 	CallOption,
 } from "./optionInterfaces";
 export type { UtilSupportsObj } from "./util";
-export type { DataConnection } from "./dataconnection/DataConnection";
+export type { DataConnection, ChunkSentNotification, SendData } from "./dataconnection/DataConnection";
 export type { MediaConnection } from "./mediaconnection";
 export type { LogLevel } from "./logger";
 export * from "./enums";

--- a/lib/exports.ts
+++ b/lib/exports.ts
@@ -20,6 +20,7 @@ export * from "./enums";
 export { BufferedConnection } from "./dataconnection/BufferedConnection/BufferedConnection";
 export { StreamConnection } from "./dataconnection/StreamConnection/StreamConnection";
 export { Cbor } from "./dataconnection/StreamConnection/Cbor";
+export { BufferedNotifyConnection } from "./dataconnection/BufferedNotifyConnection";
 export { MsgPack } from "./dataconnection/StreamConnection/MsgPack";
 export type { SerializerMapping } from "./peer";
 

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -21,6 +21,7 @@ import { Raw } from "./dataconnection/BufferedConnection/Raw";
 import { Json } from "./dataconnection/BufferedConnection/Json";
 
 import { EventEmitterWithError, PeerError } from "./peerError";
+import { BufferedNotifyConnection } from "./exports";
 
 class PeerOptions implements PeerJSOption {
 	/**
@@ -118,6 +119,7 @@ export class Peer extends EventEmitterWithError<PeerErrorType, PeerEvents> {
 		json: Json,
 		binary: BinaryPack,
 		"binary-utf8": BinaryPack,
+		notify: BufferedNotifyConnection,
 
 		default: BinaryPack,
 	};

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
 		"contributors": "git-authors-cli --print=false && prettier --write package.json && git add package.json package-lock.json && git commit -m \"chore(contributors): update and sort contributors list\"",
 		"check": "tsc --noEmit && tsc -p e2e/tsconfig.json --noEmit",
 		"watch": "parcel watch",
-		"build": "rm -rf dist && parcel build",
+		"build": "npx rimraf dist && parcel build",
 		"prepublishOnly": "npm run build",
 		"test": "jest",
 		"test:watch": "jest --watch",


### PR DESCRIPTION
I have the use case of Datachannel of trying to send files from one client to the other. The speed is not particularly an issue anymore but I would still like to have Notifications for when a chunk is complete to create **Progress Bars**. 

This PR addresses that. If connecting with the serialization 'notify', the Dataconnection will emit an additional event for when a chunk is done sending. The user can subscribe to this and use the information as they please. An example of this is:
```ts
var arr = await inputFile.arrayBuffer();
const blob = new Blob([inputFile]);
const nextId = conn.nextID;

conn.on('sentChunk', (chunk) => {
	if (chunk.id === nextId) {
		console.log('Sent chunk', chunk);
		if (chunk.n == chunk.total - 1) {
			console.log('Sent last chunk');
		}
	}
});
conn.send(arr);
```

I also have some ideas on what to do for the other Stream based serializations so I have kept the events in the base `DataConnection` without implementing these events. But `BufferedDataConnection` has got me covered nicely so far :)

I was thinking of adding a callback based api but favoured the event driven approach since I found it aligned well with what you guys were doing already. 

Haven't made tests since I couldn't get them to work on my machine but I tried it with a personal example extensively, can give more examples if necessary, some of which reside in my continuation of https://github.com/peers/peerjs/pull/1075. 

Thank you for your work and I hope this is useful to somebody as well