### PR TITLE
Fix: add null as union to existing peerConnection property type in baseconnection

### DIFF
--- a/lib/baseconnection.ts
+++ b/lib/baseconnection.ts
@@ -45,7 +45,7 @@ export abstract class BaseConnection<
 	readonly metadata: any;
 	connectionId: string;
 
-	peerConnection: RTCPeerConnection;
+	peerConnection: RTCPeerConnection | null;
 	dataChannel: RTCDataChannel;
 
 	abstract get type(): ConnectionType;


### PR DESCRIPTION
We ran into a production error where `peerConnection` was null despite the type not allowing it. Indeed the library sets this value to null when [cleaning up](https://github.com/peers/peerjs/blob/b221eb1761d4ecdefc98d33d4bfe7eb6828f4172/lib/negotiator.ts#L170) the connection.

Adding null to the type will inform developers and help them avoid this issue, especially if they are using TS with the [strict flag](https://www.typescriptlang.org/tsconfig#strict) on.