### PR TITLE
chore: remove the .js extension from import statements

### DIFF
--- a/lib/dataconnection/StreamConnection/Cbor.ts
+++ b/lib/dataconnection/StreamConnection/Cbor.ts
@@ -1,6 +1,6 @@
-import type { Peer } from "../../peer.js";
+import type { Peer } from "../../peer";
 import { Decoder, Encoder } from "cbor-x";
-import { StreamConnection } from "./StreamConnection.js";
+import { StreamConnection } from "./StreamConnection";
 
 const NullValue = Symbol.for(null);
 

--- a/lib/dataconnection/StreamConnection/MsgPack.ts
+++ b/lib/dataconnection/StreamConnection/MsgPack.ts
@@ -1,6 +1,6 @@
 import { decodeMultiStream, Encoder } from "@msgpack/msgpack";
-import { StreamConnection } from "./StreamConnection.js";
-import type { Peer } from "../../peer.js";
+import { StreamConnection } from "./StreamConnection";
+import type { Peer } from "../../peer";
 
 export class MsgPack extends StreamConnection {
 	readonly serialization = "MsgPack";

--- a/lib/dataconnection/StreamConnection/StreamConnection.ts
+++ b/lib/dataconnection/StreamConnection/StreamConnection.ts
@@ -1,6 +1,6 @@
-import logger from "../../logger.js";
-import type { Peer } from "../../peer.js";
-import { DataConnection } from "../DataConnection.js";
+import logger from "../../logger";
+import type { Peer } from "../../peer";
+import { DataConnection } from "../DataConnection";
 
 export abstract class StreamConnection extends DataConnection {
 	private _CHUNK_SIZE = 1024 * 8 * 4;


### PR DESCRIPTION
I am developing a wrapper for react-native using peerjs. I am getting a build error and have fixed it.