### PR TITLE
fix : navigator is not defined (Issue #1165)

### DIFF
--- a/lib/supports.ts
+++ b/lib/supports.ts
@@ -5,7 +5,7 @@ const webRTCAdapter: typeof webRTCAdapter_import =
 	webRTCAdapter_import.default || webRTCAdapter_import;
 
 export const Supports = new (class {
-	readonly isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform);
+	readonly isIOS = navigator ? (["iPad", "iPhone", "iPod"].includes(navigator.platform)) : false;  
 	readonly supportedBrowsers = ["firefox", "chrome", "safari"];
 
 	readonly minFirefoxVersion = 59;


### PR DESCRIPTION
**Title**: Fix Issue #1165: Navigator is not defined.  

**Description**: Today many people use NextJS for building webapps. But when they importing Peer from peerjs they get this error because when webpack compile it in server side, navigator is not present there. 

**Issue**: [link of issue #1165](https://github.com/peers/peerjs/issues/1165)

**Changes Made**:

In peerjs/dist/bundel.mjs : I made change in this file as given below literally remove the error from compiling and building in simple import without using useeffect or dynamic import. Only 'use client' is defined at top.


```
if (typeof navigator !== 'undefined') {
            this.isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform)
        }
        else this.isIOS = false;
```

So this means, checking the navigator in support.ts is able to solve this problem.

Now :` readonly isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform);`

Change to : `readonly isIOS = navigator ? (["iPad", "iPhone", "iPod"].includes(navigator.platform)) : false;`

The navigator.platform only works when navigator is available else isIOS assigned false.


**Reviewer Requests**:

@jonasgloning : Please review the changes and provide feedback.