### PR TITLE
Fix Issue #1165: Navigator is not defined.

### DIFF
--- a/lib/supports.ts
+++ b/lib/supports.ts
@@ -5,7 +5,7 @@ const webRTCAdapter: typeof webRTCAdapter_import =
 	webRTCAdapter_import.default || webRTCAdapter_import;
 
 export const Supports = new (class {
-	readonly isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform);
+	readonly isIOS = navigator ? (["iPad", "iPhone", "iPod"].includes(navigator.platform)) : false;
 	readonly supportedBrowsers = ["firefox", "chrome", "safari"];
 
 	readonly minFirefoxVersion = 59;


### PR DESCRIPTION
**Cause**: Today many people use NextJS for building webapps. But when they importing Peer from peerjs they get this error because when webpack compile it in server side, navigator is not present there.

**Issue**: [link](https://github.com/peers/peerjs/issues/1165)

**Changes Made**:

In peerjs/dist/bundel.mjs : I made change in this file as given below literally remove the error from compiling and building in simple import without using useeffect or dynamic import. Only 'use client' is defined at top.

```
if (typeof navigator !== 'undefined') {
            this.isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform)
        }
        else this.isIOS = false;
```
So this means, checking the navigator in support.ts is able to solve this problem.

_Now_ :` readonly isIOS = ["iPad", "iPhone", "iPod"].includes(navigator.platform);`

_Change to_ : `readonly isIOS = navigator ? (["iPad", "iPhone", "iPod"].includes(navigator.platform)) : false;`

The _navigator.platform_ only works when navigator is available else isIOS assigned false.

**Reviewer Requests**:

@jonasgloning : Please review the changes and provide feedback.