### PR TITLE
test: add new unit test in test case reconnect

### DIFF
--- a/__test__/peer.spec.ts
+++ b/__test__/peer.spec.ts
@@ -195,6 +195,47 @@ describe("Peer", () => {
 			});
 		});
 
+        it("reconnect => disconnect => destroy", (done) => {
+            const peer1 = new Peer("1", { port: 8080, host: "localhost" });
+
+            peer1.once("open", () => {
+                expect(peer1.open).toBe(true);
+
+                peer1.once("disconnected", () => {
+                    expect(peer1.disconnected).toBe(true);
+                    expect(peer1.destroyed).toBe(false);
+                    expect(peer1.open).toBe(false);
+
+                    peer1.once("open", (id) => {
+                        expect(id).toBe("1");
+                        expect(peer1.disconnected).toBe(false);
+                        expect(peer1.destroyed).toBe(false);
+                        expect(peer1.open).toBe(true);
+
+                        peer1.once("disconnected", () => {
+                            expect(peer1.disconnected).toBe(true);
+                            expect(peer1.destroyed).toBe(false);
+                            expect(peer1.open).toBe(false);
+
+                            peer1.once("close", () => {
+                                expect(peer1.disconnected).toBe(true);
+                                expect(peer1.destroyed).toBe(true);
+                                expect(peer1.open).toBe(false);
+
+                                done();
+                            });
+                        });
+
+                        peer1.destroy();
+                    });
+
+                    peer1.reconnect();
+                });
+
+                peer1.disconnect();
+            });
+        });
+
 		it("destroy peer if no id and no connection", (done) => {
 			mockServer.stop();
 


### PR DESCRIPTION
**What was added?**
A new test named as: (reconnect => disconnect => destroy) has been added in the "reconnect" test case in the __test__/peer.spec.ts file

**How important is this new test?**
This new test is important because there were already other tests that analyzed cases such as disconnect => reconnect but not the opposite, reconnect => disconnect, which could allow bugs to pass after reconnecting and disconnecting. This was solved by adding the new test that checks if everything will be ok after reconnecting and disconnecting

**What was done after implementing the new test?**
After implementing the test, I analyzed whether it would fulfill its role by causing it to give an error on purpose, and I confirmed its effectiveness in avoiding future bugs after reconnecting and disconnecting, everything is ok.

**It's OK, Tested and Approved**
I hope you accept the PR with the test to avoid future bugs! **Thank you for your attention**
![image](https://github.com/peers/peerjs/assets/115284250/1a50364d-6402-4e36-998e-84c0c75a0a5f)
