### PR TITLE
Expose addEventListner to allow for proper use of the underlying websocket

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -147,6 +147,13 @@ export class Socket extends EventEmitter {
 		this._socket!.send(message);
 	}
 
+	/** Exposed listening */
+	addEventListener(event: "message" | "error" | "open" | "close", callback: (event: Event) => void): void {
+		if (this._disconnected) return;
+
+		this._socket!.addEventListener(event, callback)
+	}
+
 	close(): void {
 		if (this._disconnected) {
 			return;


### PR DESCRIPTION
Been working on a project recently and I noticed that there is no safe way to listen to the underlying websocket, I assumed this was because you weren't intended to but it looks like PeerServer actively supports sending and listening to the websocket so this seems like an oversight to me.