### PR TITLE
Fix: inline package version (not shipping whole package.json in the bundle)

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,8 @@
 import { util } from "./util";
 import logger from "./logger";
 import type { PeerJSOption } from "./optionInterfaces";
-import { version } from "../package.json";
+
+const version = process.env.npm_package_version;
 
 export class API {
 	constructor(private readonly _options: PeerJSOption) {}

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "eventemitter3";
 import logger from "./logger";
 import { ServerMessageType, SocketEventType } from "./enums";
-import { version } from "../package.json";
+
+const version = process.env.npm_package_version;
 
 /**
  * An abstraction on top of WebSockets to provide fastest

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@swc/core": "^1.3.27",
 				"@swc/jest": "^0.2.24",
 				"@types/jasmine": "^4.3.4",
+				"@types/node": "^22.13.7",
 				"@wdio/browserstack-service": "^8.11.2",
 				"@wdio/cli": "^8.11.2",
 				"@wdio/globals": "^8.11.2",
@@ -4599,13 +4600,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.5.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
-			"integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+			"version": "22.13.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+			"integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -19438,9 +19439,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -117,12 +117,16 @@
 			"source": "lib/exports.ts"
 		},
 		"main": {
+			"context": "browser",
+			"outputFormat": "commonjs",
 			"source": "lib/exports.ts",
 			"sourceMap": {
 				"inlineSources": true
 			}
 		},
 		"module": {
+			"context": "browser",
+			"outputFormat": "esmodule",
 			"source": "lib/exports.ts",
 			"includeNodeModules": [
 				"eventemitter3"
@@ -185,6 +189,7 @@
 		"@swc/core": "^1.3.27",
 		"@swc/jest": "^0.2.24",
 		"@types/jasmine": "^4.3.4",
+		"@types/node": "^22.13.7",
 		"@wdio/browserstack-service": "^8.11.2",
 		"@wdio/cli": "^8.11.2",
 		"@wdio/globals": "^8.11.2",
@@ -212,5 +217,10 @@
 	"alias": {
 		"process": false,
 		"buffer": false
+	},
+	"@parcel/transformer-js": {
+		"inlineEnvironment": [
+			"npm_package_version"
+		]
 	}
 }


### PR DESCRIPTION
Using parcel's `inlineEnvironment` https://github.com/parcel-bundler/parcel/issues/8470#issuecomment-1287771011 to inline the version so the whole package.json content is not included in the bundle

Must use `"context": "browser"` for targets.main and targets.module, default context "node" can't inline `process.env.npm_package_version`

Added @types/node for `process`'s type definition

Closes #1322