### PR TITLE
fix: prevent zombie WebSocket when destroy() called during init

### DIFF
--- a/__test__/peer.zombie.spec.ts
+++ b/__test__/peer.zombie.spec.ts
@@ -1,0 +1,99 @@
+import "./setup";
+import { Peer } from "../lib/peer";
+import { API } from "../lib/api";
+import { Socket } from "../lib/socket";
+import {
+	expect,
+	describe,
+	it,
+	beforeEach,
+	afterEach,
+	jest,
+} from "@jest/globals";
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("Peer", () => {
+	describe("zombie WebSocket after destroy (F1)", () => {
+		let resolveId: (id: string) => void;
+		let rejectId: (error: Error) => void;
+		let retrieveIdSpy: ReturnType<typeof jest.spyOn>;
+		let socketStartSpy: ReturnType<typeof jest.spyOn>;
+
+		beforeEach(() => {
+			retrieveIdSpy = jest
+				.spyOn(API.prototype, "retrieveId")
+				.mockImplementation(
+					() =>
+						new Promise<string>((resolve, reject) => {
+							resolveId = resolve;
+							rejectId = reject;
+						}),
+				);
+			socketStartSpy = jest.spyOn(Socket.prototype, "start");
+		});
+
+		afterEach(() => {
+			retrieveIdSpy.mockRestore();
+			socketStartSpy.mockRestore();
+		});
+
+		it("should not start socket after destroy()", async () => {
+			const peer = new Peer();
+			expect(socketStartSpy).not.toHaveBeenCalled();
+
+			peer.destroy();
+			expect(peer.destroyed).toBe(true);
+
+			resolveId("server-assigned-id");
+			await flushPromises();
+
+			expect(socketStartSpy).not.toHaveBeenCalled();
+		});
+
+		it("should not emit error when retrieveId rejects after destroy()", async () => {
+			const peer = new Peer();
+			const errorHandler = jest.fn();
+			peer.on("error", errorHandler);
+
+			peer.destroy();
+
+			rejectId(new Error("network failure"));
+			await flushPromises();
+
+			expect(errorHandler).not.toHaveBeenCalled();
+		});
+
+		it("reconnect() still works with the guard in _initialize()", async () => {
+			const peer = new Peer();
+
+			resolveId("original-id");
+			await flushPromises();
+
+			expect(socketStartSpy).toHaveBeenCalledTimes(1);
+
+			peer.disconnect();
+			expect(peer.disconnected).toBe(true);
+
+			socketStartSpy.mockClear();
+			peer.reconnect();
+
+			expect(socketStartSpy).toHaveBeenCalledTimes(1);
+
+			peer.destroy();
+		});
+
+		it("normal flow: resolve before destroy — no zombie", async () => {
+			const peer = new Peer();
+
+			resolveId("server-assigned-id");
+			await flushPromises();
+
+			expect(socketStartSpy).toHaveBeenCalledTimes(1);
+			expect(peer.destroyed).toBe(false);
+
+			peer.destroy();
+			expect(peer.destroyed).toBe(true);
+		});
+	});
+});

--- a/lib/peer.ts
+++ b/lib/peer.ts
@@ -294,7 +294,10 @@ export class Peer extends EventEmitterWithError<PeerErrorType, PeerEvents> {
 			this._api
 				.retrieveId()
 				.then((id) => this._initialize(id))
-				.catch((error) => this._abort(PeerErrorType.ServerError, error));
+				.catch((error) => {
+					if (!this.destroyed && !this.disconnected)
+						this._abort(PeerErrorType.ServerError, error);
+				});
 		}
 	}
 
@@ -341,6 +344,8 @@ export class Peer extends EventEmitterWithError<PeerErrorType, PeerEvents> {
 
 	/** Initialize a connection with the server. */
 	private _initialize(id: string): void {
+		if (this.destroyed || this.disconnected) return;
+
 		this._id = id;
 		this.socket.start(id, this._options.token!);
 	}
@@ -739,6 +744,9 @@ export class Peer extends EventEmitterWithError<PeerErrorType, PeerEvents> {
 		this._api
 			.listAllPeers()
 			.then((peers) => cb(peers))
-			.catch((error) => this._abort(PeerErrorType.ServerError, error));
+			.catch((error) => {
+				if (!this.destroyed && !this.disconnected)
+					this._abort(PeerErrorType.ServerError, error);
+			});
 	}
 }


### PR DESCRIPTION
When `new Peer()` is created without an ID, `retrieveId()` fires an async HTTP request. 

If `destroy()` is called before it resolves, `_initialize()` runs unconditionally on the destroyed peer, creating a WebSocket that sends heartbeats indefinitely with no event listeners and no API path to close it.

Add a guard in `_initialize()` to return early if the peer is destroyed or disconnected. Also guard the async error handlers in `retrieveId()` and `listAllPeers()` to suppress spurious error events on dead peers.

potentially related to #789